### PR TITLE
feat(action): add optional input name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,11 @@ jobs:
             openapi-generator-cli --version
             exit 1
           fi
+
+      - name: Run action with name
+        uses: ./
+        with:
+          name: openapi-generator
+
+      - name: Check name
+        run: openapi-generator version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 🟢 Set up GitHub Actions workflow with [OpenAPI Generator CLI](https://openapi-generator.tech/docs/installation/).
 
-This action installs Java, downloads the OpenAPI Generator CLI JAR, caches it by version, and exposes `openapi-generator-cli` on `PATH`.
+This action installs Java, downloads the OpenAPI Generator CLI JAR, caches it by version, and exposes a binary on `PATH`.
 
 ## Quick Start
 
@@ -50,6 +50,16 @@ See [action.yml](action.yml)
 - uses: remarkablemark/setup-openapi@v1
   with:
     version: 7.21.0
+```
+
+### `name`
+
+**Optional**: The OpenAPI Generator CLI binary name. Defaults to `openapi-generator-cli`.
+
+```yaml
+- uses: remarkablemark/setup-openapi@v1
+  with:
+    name: openapi-generator-cli
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   version:
     description: OpenAPI Generator CLI version
     default: 7.21.0
+  name:
+    description: OpenAPI Generator CLI name
+    default: openapi-generator-cli
 
 runs:
   using: composite
@@ -53,13 +56,13 @@ runs:
         BIN_DIR="$RUNNER_TEMP/openapi-generator-cli-bin"
         mkdir -p "$BIN_DIR"
 
-        cat > "$BIN_DIR/openapi-generator-cli" <<EOF
+        cat > "$BIN_DIR/$NAME" <<EOF
         #!/usr/bin/env bash
         exec java -jar "$JAR_PATH" "\$@"
         EOF
-        chmod +x "$BIN_DIR/openapi-generator-cli"
+        chmod +x "$BIN_DIR/$NAME"
 
-        cat > "$BIN_DIR/openapi-generator-cli.cmd" <<EOF
+        cat > "$BIN_DIR/$NAME.cmd" <<EOF
         @echo off
         java -jar "$JAR_PATH" %*
         EOF
@@ -67,6 +70,7 @@ runs:
         echo "$BIN_DIR" >> "$GITHUB_PATH"
       env:
         JAR_PATH: ${{ steps.path.outputs.JAR_PATH }}
+        NAME: ${{ inputs.name }}
 
 branding:
   icon: check-circle


### PR DESCRIPTION
## What is the motivation for this pull request?

Allow workflows to customize the installed OpenAPI Generator CLI binary name instead of always using openapi-generator-cli.

## What is the current behavior?

The action always installs the wrapper binary as `openapi-generator-cli` and does not provide a way to rename it.

## What is the new behavior?

The action now supports an optional `name` input that controls the installed wrapper binary name while keeping `openapi-generator-cli` as the default.

The `README.md` documents the new input and the test workflow verifies a custom binary name.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation